### PR TITLE
This hot fix should update the github action golangci-lint 

### DIFF
--- a/.github/workflows/golang-build-test-on-PR.yml
+++ b/.github/workflows/golang-build-test-on-PR.yml
@@ -1,4 +1,4 @@
-name: Go Build and Test PR
+name: go-build-and-test-pr
 
 on:
   pull_request:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,5 +1,15 @@
 name: golangci-lint
-on: [push, pull_request]
+on:
+  push:
+    push:
+      branches-ignore:
+        - 'master'
+    pull_request:
+      branches:
+        - 'releases/**'
+        - '!releases/**-alpha'
+        - 'hot-fix_**'
+
 jobs:
   golangci-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The issue it solves is that the job should not get triggered twice on push and pull request.